### PR TITLE
Fix smart cache path handling bug

### DIFF
--- a/nexlify/ml/nexlify_smart_cache.py
+++ b/nexlify/ml/nexlify_smart_cache.py
@@ -347,7 +347,7 @@ class SmartCache:
         # Two-tier cache
         self.memory_cache = LRUCache(max_size_mb=memory_cache_mb)
         self.disk_cache = ChunkedCompressedStorage(
-            cache_dir=cache_dir / 'disk_cache',
+            cache_dir=self.cache_dir / 'disk_cache',
             chunk_size_kb=1024
         ) if enable_compression else None
 


### PR DESCRIPTION
Fixed TypeError when initializing SmartCache - was using string instead of Path object for path division operation.

Bug: cache_dir / 'disk_cache' failed when cache_dir was a string
Fix: Use self.cache_dir (Path object) instead of cache_dir parameter

This fixes agent creation failures in GPU training.