### PR TITLE
Debug BTC historical data fetching issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 ccxt==4.1.22
 pandas==2.0.3
 numpy==1.24.3
+pyarrow==14.0.1  # For parquet file support in historical data cache
 
 # Async support
 aiohttp==3.8.5


### PR DESCRIPTION
…ency

Issues fixed:
1. Progress calculation bug - Progress bar now shows batch counts and logs less frequently (every 10%) to reduce noise
2. Improved logging - Now shows detailed breakdown: raw candles fetched, duplicates removed, and final filtered count
3. Better error handling - Clear warnings when data is filtered out and why
4. Added pyarrow dependency for parquet cache support

Changes:
- nexlify_data/nexlify_historical_data_fetcher.py:
  * Modified _create_progress_bar to log only at 10% intervals with clearer messaging
  * Enhanced _fetch_with_retry to log detailed fetch statistics (raw/dedup/filtered counts)
  * Added warning when all candles are outside requested date range
  * Improved error messages in fetch_historical_data
  * Removed duplicate "Cleaning data..." log message
- requirements.txt:
  * Added pyarrow==14.0.1 for parquet file support

This fixes the confusing progress messages where it showed "Progress: 4.7% (721/15360 candles)" but then "✓ Fetched 0 candles" - now it clearly distinguishes between batch counts and final filtered results.