### PR TITLE
Enhance PredictiveEngine with blended-signal model, per-symbol tuning, and confidence calibration

### DIFF
--- a/nexlify/strategies/nexlify_predictive_features.py
+++ b/nexlify/strategies/nexlify_predictive_features.py
@@ -237,15 +237,25 @@ class PredictiveEngine:
         train_prices = prices[:split_idx]
         val_prices = prices[split_idx:]
 
-        grid = [
-            (0.5, 0.3, 0.2),
-            (0.45, 0.35, 0.2),
-            (0.4, 0.4, 0.2),
-            (0.4, 0.3, 0.3),
-            (0.35, 0.45, 0.2),
-        ]
-        deadzones = [0.0003, 0.0005, 0.0008]
-        signal_scales = [0.75, 1.0, 1.25]
+        # Keep tuning compact to avoid long optimization cycles in runtime/CI.
+        if len(prices) < 400:
+            grid = [
+                (0.5, 0.3, 0.2),
+                (0.45, 0.35, 0.2),
+                (0.4, 0.3, 0.3),
+            ]
+            deadzones = [0.0003, 0.0005]
+            signal_scales = [0.9, 1.0]
+        else:
+            grid = [
+                (0.5, 0.3, 0.2),
+                (0.45, 0.35, 0.2),
+                (0.4, 0.4, 0.2),
+                (0.4, 0.3, 0.3),
+                (0.35, 0.45, 0.2),
+            ]
+            deadzones = [0.0003, 0.0005, 0.0008]
+            signal_scales = [0.75, 1.0, 1.25]
 
         best = {"accuracy": 0.0, "params": self.default_params.copy()}
 
@@ -321,25 +331,41 @@ class PredictiveEngine:
 
     def _predict_with_params(self, current_price: float, historical_data: List[float], params: Dict) -> float:
         """Predict expected return using provided parameters."""
-        df = pd.DataFrame({"price": historical_data})
-        df["sma_short"] = df["price"].rolling(window=8).mean()
-        df["sma_long"] = df["price"].rolling(window=34).mean()
-        df["ema"] = df["price"].ewm(span=21).mean()
-        df["returns"] = df["price"].pct_change()
-        df["momentum"] = df["returns"].rolling(window=5).mean()
+        if not historical_data:
+            return 0.0
 
-        trend_window = min(20, len(df))
-        recent = np.array(df["price"].iloc[-trend_window:])
+        # Fast rolling features (avoids DataFrame creation inside tight tuning loop)
+        short_slice = historical_data[-8:] if len(historical_data) >= 8 else historical_data
+        long_slice = historical_data[-34:] if len(historical_data) >= 34 else historical_data
+        last_short = float(sum(short_slice) / len(short_slice))
+        last_long = float(sum(long_slice) / len(long_slice)) if long_slice else 0.0
+
+        # EMA(21)
+        alpha = 2.0 / (21.0 + 1.0)
+        ema = float(historical_data[0])
+        for price in historical_data[1:]:
+            ema = (float(price) * alpha) + (ema * (1.0 - alpha))
+
+        # Momentum from last 5 returns
+        if len(historical_data) >= 2:
+            returns = [
+                (historical_data[i] - historical_data[i - 1]) / historical_data[i - 1]
+                for i in range(1, len(historical_data))
+                if historical_data[i - 1] != 0
+            ]
+            recent_returns = returns[-5:] if len(returns) >= 5 else returns
+            momentum = float(sum(recent_returns) / len(recent_returns)) if recent_returns else 0.0
+        else:
+            momentum = 0.0
+
+        trend_window = min(20, len(historical_data))
+        recent = np.array(historical_data[-trend_window:], dtype=float)
         x_axis = np.arange(trend_window)
         slope = np.polyfit(x_axis, recent, 1)[0] if trend_window >= 3 else 0.0
         trend_signal = slope / current_price if current_price > 0 else 0.0
 
-        last_short = df["sma_short"].iloc[-1]
-        last_long = df["sma_long"].iloc[-1]
-        last_ema = df["ema"].iloc[-1]
-        momentum = float(df["momentum"].iloc[-1]) if not pd.isna(df["momentum"].iloc[-1]) else 0.0
-        ma_signal = (last_short - last_long) / last_long if last_long and not pd.isna(last_long) else 0.0
-        mean_reversion_signal = (last_ema - current_price) / current_price if current_price > 0 else 0.0
+        ma_signal = (last_short - last_long) / last_long if last_long else 0.0
+        mean_reversion_signal = (ema - current_price) / current_price if current_price > 0 else 0.0
 
         return (
             params["trend_weight"] * (trend_signal + ma_signal)

--- a/nexlify/strategies/nexlify_predictive_features.py
+++ b/nexlify/strategies/nexlify_predictive_features.py
@@ -28,11 +28,23 @@ class PredictiveEngine:
         self.config = config or {}
         self.price_history: Dict[str, deque] = {}
         self.predictions_cache: Dict[str, Dict] = {}
+        self.prediction_history: Dict[str, deque] = {}
         self.max_history_length = 1000
+        self.model_params: Dict[str, Dict] = {}
 
-        # Model parameters (simplified for now)
+        # Model parameters
         self.prediction_window = 60  # minutes
         self.confidence_threshold = 0.6
+
+        # Default blended-signal weights (can be tuned per symbol)
+        self.default_params = {
+            "trend_weight": 0.45,
+            "momentum_weight": 0.35,
+            "mean_reversion_weight": 0.20,
+            "deadzone": 0.0005,
+            "horizon": 5,
+            "signal_scale": 1.0,
+        }
 
         logger.info("🔮 Predictive Engine initialized")
 
@@ -60,35 +72,61 @@ class PredictiveEngine:
                     "change_percent": 0.0,
                 }
 
-            # Simple moving average prediction (can be enhanced with ML)
-            short_window = 5
-            long_window = 20
-
             df = pd.DataFrame({"price": historical_data})
+            params = self.model_params.get(symbol, self.default_params)
+            horizon = max(1, int(params.get("horizon", 5)))
+
+            # Core features
+            short_window = 8
+            long_window = 34
+            ema_span = 21
 
             # Calculate moving averages
             df["sma_short"] = df["price"].rolling(window=short_window).mean()
             df["sma_long"] = df["price"].rolling(window=long_window).mean()
+            df["ema"] = df["price"].ewm(span=ema_span).mean()
 
             # Calculate momentum
-            df["momentum"] = df["price"].diff()
-            df["momentum_ma"] = df["momentum"].rolling(window=5).mean()
+            df["returns"] = df["price"].pct_change()
+            df["momentum"] = df["returns"].rolling(window=5).mean()
 
-            # Simple trend prediction
+            # Trend strength from linear regression slope
+            trend_window = min(20, len(df))
+            recent = np.array(df["price"].iloc[-trend_window:])
+            x_axis = np.arange(trend_window)
+            slope = np.polyfit(x_axis, recent, 1)[0] if trend_window >= 3 else 0.0
+            trend_signal = slope / current_price if current_price > 0 else 0.0
+
+            # Individual normalized signals
             last_short = df["sma_short"].iloc[-1]
             last_long = df["sma_long"].iloc[-1]
-            momentum = df["momentum_ma"].iloc[-1]
+            last_ema = df["ema"].iloc[-1]
+            momentum = float(df["momentum"].iloc[-1]) if not pd.isna(df["momentum"].iloc[-1]) else 0.0
+
+            ma_signal = (
+                (last_short - last_long) / last_long if last_long and not pd.isna(last_long) else 0.0
+            )
+            mean_reversion_signal = (
+                (last_ema - current_price) / current_price if current_price > 0 else 0.0
+            )
+
+            # Blended forecast return
+            expected_return = (
+                params["trend_weight"] * (trend_signal + ma_signal)
+                + params["momentum_weight"] * momentum
+                + params["mean_reversion_weight"] * mean_reversion_signal
+            )
+            expected_return *= params.get("signal_scale", 1.0)
 
             # Predict direction
-            if last_short > last_long and momentum > 0:
+            if expected_return > params["deadzone"]:
                 direction = "bullish"
-                predicted_change = abs(momentum) * 1.5
-            elif last_short < last_long and momentum < 0:
+            elif expected_return < -params["deadzone"]:
                 direction = "bearish"
-                predicted_change = abs(momentum) * 1.5
             else:
                 direction = "neutral"
-                predicted_change = abs(momentum) * 0.5
+
+            predicted_change = current_price * abs(expected_return) * np.sqrt(horizon)
 
             # Calculate predicted price
             if direction == "bullish":
@@ -98,9 +136,21 @@ class PredictiveEngine:
             else:
                 predicted_price = current_price
 
-            # Calculate confidence based on trend strength
-            trend_strength = abs(last_short - last_long) / current_price
-            confidence = min(trend_strength * 100, 0.95)
+            # Confidence based on signal agreement and stability
+            signal_agreement = np.mean(
+                [
+                    np.sign(trend_signal + ma_signal),
+                    np.sign(momentum),
+                    np.sign(mean_reversion_signal),
+                ]
+            )
+            volatility = float(df["returns"].rolling(window=20).std().iloc[-1])
+            volatility = volatility if not pd.isna(volatility) else 0.0
+            signal_strength = abs(expected_return)
+            stability_factor = 1.0 / (1.0 + max(volatility, 1e-6) * 100)
+            confidence = min(max(signal_strength * 120, 0.05), 0.95)
+            confidence = float(min(0.95, confidence * (0.5 + abs(signal_agreement) * 0.5) * stability_factor))
+            confidence = self._calibrate_confidence(symbol, confidence, direction)
 
             change_percent = ((predicted_price - current_price) / current_price) * 100
 
@@ -112,6 +162,8 @@ class PredictiveEngine:
                 "direction": direction,
                 "change_percent": change_percent,
                 "timestamp": datetime.now().isoformat(),
+                "expected_return": expected_return,
+                "model_version": "blended_signal_v2",
             }
 
             # Cache prediction
@@ -127,6 +179,188 @@ class PredictiveEngine:
                 "direction": "neutral",
                 "change_percent": 0.0,
             }
+
+    def record_prediction_outcome(
+        self,
+        symbol: str,
+        predicted_direction: str,
+        entry_price: float,
+        realized_price: float,
+    ) -> None:
+        """Store realized outcome to calibrate confidence over time."""
+        if symbol not in self.prediction_history:
+            self.prediction_history[symbol] = deque(maxlen=500)
+
+        if entry_price <= 0:
+            return
+
+        realized_return = (realized_price - entry_price) / entry_price
+        if abs(realized_return) <= self.default_params["deadzone"]:
+            outcome_direction = "neutral"
+        elif realized_return > 0:
+            outcome_direction = "bullish"
+        else:
+            outcome_direction = "bearish"
+
+        self.prediction_history[symbol].append(
+            {
+                "predicted_direction": predicted_direction,
+                "realized_direction": outcome_direction,
+                "is_correct": predicted_direction == outcome_direction,
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+
+    def tune_model_for_symbol(
+        self,
+        symbol: str,
+        historical_data: List[float],
+        horizon: int = 5,
+        min_samples: int = 120,
+    ) -> Dict:
+        """
+        Tune model weights for a symbol using walk-forward directional accuracy.
+
+        Returns:
+            Dict with best parameters and achieved validation accuracy.
+        """
+        if len(historical_data) < min_samples:
+            return {
+                "symbol": symbol,
+                "status": "insufficient_data",
+                "required_samples": min_samples,
+                "available_samples": len(historical_data),
+            }
+
+        prices = np.asarray(historical_data, dtype=float)
+        split_idx = int(len(prices) * 0.8)
+        train_prices = prices[:split_idx]
+        val_prices = prices[split_idx:]
+
+        grid = [
+            (0.5, 0.3, 0.2),
+            (0.45, 0.35, 0.2),
+            (0.4, 0.4, 0.2),
+            (0.4, 0.3, 0.3),
+            (0.35, 0.45, 0.2),
+        ]
+        deadzones = [0.0003, 0.0005, 0.0008]
+        signal_scales = [0.75, 1.0, 1.25]
+
+        best = {"accuracy": 0.0, "params": self.default_params.copy()}
+
+        for trend_w, mom_w, mr_w in grid:
+            for deadzone in deadzones:
+                for signal_scale in signal_scales:
+                    params = {
+                        "trend_weight": trend_w,
+                        "momentum_weight": mom_w,
+                        "mean_reversion_weight": mr_w,
+                        "deadzone": deadzone,
+                        "horizon": horizon,
+                        "signal_scale": signal_scale,
+                    }
+                    acc = self._cross_validated_accuracy(train_prices, params)
+                    # Blend CV and holdout so we avoid overfitting to just one split
+                    holdout_acc = self._directional_accuracy(val_prices, params)
+                    blended_acc = (acc * 0.7) + (holdout_acc * 0.3)
+                    if blended_acc > best["accuracy"]:
+                        best = {"accuracy": blended_acc, "params": params}
+
+        self.model_params[symbol] = best["params"]
+        return {
+            "symbol": symbol,
+            "status": "tuned",
+            "validation_accuracy": best["accuracy"],
+            "target_reached": best["accuracy"] >= 0.70,
+            "best_params": best["params"],
+            "train_samples": len(train_prices),
+            "validation_samples": len(val_prices),
+        }
+
+    def _cross_validated_accuracy(self, prices: np.ndarray, params: Dict) -> float:
+        """Time-series style cross-validation to reduce overfitting risk."""
+        fold_count = 3
+        min_fold_size = 80
+        if len(prices) < min_fold_size:
+            return self._directional_accuracy(prices, params)
+
+        accuracies = []
+        for fold_idx in range(1, fold_count + 1):
+            cutoff = int(len(prices) * (0.5 + (fold_idx * 0.15)))
+            cutoff = min(max(cutoff, min_fold_size), len(prices) - 1)
+            fold_prices = prices[:cutoff]
+            accuracies.append(self._directional_accuracy(fold_prices, params))
+
+        valid = [acc for acc in accuracies if acc > 0]
+        return float(np.mean(valid)) if valid else 0.0
+
+    def _directional_accuracy(self, prices: np.ndarray, params: Dict) -> float:
+        """Compute walk-forward directional accuracy for a parameter set."""
+        lookback = 40
+        horizon = max(1, int(params.get("horizon", 5)))
+        if len(prices) <= lookback + horizon:
+            return 0.0
+
+        correct = 0
+        total = 0
+        for idx in range(lookback, len(prices) - horizon):
+            window = prices[idx - lookback : idx].tolist()
+            current = float(prices[idx])
+            pred = self._predict_with_params(current, window, params)
+            realized = float((prices[idx + horizon] - current) / current)
+
+            if abs(realized) <= params["deadzone"]:
+                continue
+
+            total += 1
+            if (pred > 0 and realized > 0) or (pred < 0 and realized < 0):
+                correct += 1
+
+        return correct / total if total > 0 else 0.0
+
+    def _predict_with_params(self, current_price: float, historical_data: List[float], params: Dict) -> float:
+        """Predict expected return using provided parameters."""
+        df = pd.DataFrame({"price": historical_data})
+        df["sma_short"] = df["price"].rolling(window=8).mean()
+        df["sma_long"] = df["price"].rolling(window=34).mean()
+        df["ema"] = df["price"].ewm(span=21).mean()
+        df["returns"] = df["price"].pct_change()
+        df["momentum"] = df["returns"].rolling(window=5).mean()
+
+        trend_window = min(20, len(df))
+        recent = np.array(df["price"].iloc[-trend_window:])
+        x_axis = np.arange(trend_window)
+        slope = np.polyfit(x_axis, recent, 1)[0] if trend_window >= 3 else 0.0
+        trend_signal = slope / current_price if current_price > 0 else 0.0
+
+        last_short = df["sma_short"].iloc[-1]
+        last_long = df["sma_long"].iloc[-1]
+        last_ema = df["ema"].iloc[-1]
+        momentum = float(df["momentum"].iloc[-1]) if not pd.isna(df["momentum"].iloc[-1]) else 0.0
+        ma_signal = (last_short - last_long) / last_long if last_long and not pd.isna(last_long) else 0.0
+        mean_reversion_signal = (last_ema - current_price) / current_price if current_price > 0 else 0.0
+
+        return (
+            params["trend_weight"] * (trend_signal + ma_signal)
+            + params["momentum_weight"] * momentum
+            + params["mean_reversion_weight"] * mean_reversion_signal
+        ) * params.get("signal_scale", 1.0)
+
+    def _calibrate_confidence(self, symbol: str, base_confidence: float, direction: str) -> float:
+        """Calibrate confidence using symbol-specific recent hit rate."""
+        history = self.prediction_history.get(symbol)
+        if not history or len(history) < 20:
+            return base_confidence
+
+        directional = [h for h in history if h["predicted_direction"] == direction]
+        if len(directional) < 8:
+            return base_confidence
+
+        hit_rate = sum(1 for h in directional if h["is_correct"]) / len(directional)
+        # Pull confidence toward empirical hit rate while keeping bounded confidence
+        calibrated = (base_confidence * 0.6) + (hit_rate * 0.4)
+        return float(max(0.05, min(0.95, calibrated)))
 
     def analyze_volatility(self, symbol: str, prices: List[float]) -> Dict:
         """

--- a/tests/test_predictive_features.py
+++ b/tests/test_predictive_features.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for PredictiveEngine blended-signal prediction flow."""
+
+import pytest
+
+pytest.importorskip("aiohttp")
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
+
+from nexlify.strategies.nexlify_predictive_features import PredictiveEngine
+
+
+def _generate_prices(length: int = 200, start: float = 100.0):
+    """Generate deterministic non-flat price data for tests."""
+    prices = [start]
+    for idx in range(1, length):
+        drift = 0.002 if (idx // 25) % 2 == 0 else -0.001
+        prices.append(prices[-1] * (1 + drift))
+    return prices
+
+
+def test_predict_price_insufficient_history_returns_neutral():
+    engine = PredictiveEngine()
+
+    result = engine.predict_price("BTCUSDT", 100.0, [100.0, 100.5, 100.8])
+
+    assert result["predicted_price"] == 100.0
+    assert result["confidence"] == 0.0
+    assert result["direction"] == "neutral"
+    assert result["change_percent"] == 0.0
+
+
+def test_predict_price_returns_enriched_prediction_payload():
+    engine = PredictiveEngine()
+    prices = _generate_prices(180)
+    current_price = prices[-1]
+
+    result = engine.predict_price("BTCUSDT", current_price, prices)
+
+    assert result["symbol"] == "BTCUSDT"
+    assert "expected_return" in result
+    assert "model_version" in result
+    assert result["model_version"] == "blended_signal_v2"
+    assert 0.0 <= result["confidence"] <= 0.95
+    assert result["direction"] in {"bullish", "bearish", "neutral"}
+
+
+def test_tune_model_for_symbol_persists_best_params_with_signal_scale():
+    engine = PredictiveEngine()
+    prices = _generate_prices(240)
+
+    result = engine.tune_model_for_symbol("ETHUSDT", prices, horizon=5)
+
+    assert result["status"] == "tuned"
+    assert "validation_accuracy" in result
+    assert "best_params" in result
+    assert "signal_scale" in result["best_params"]
+    assert "ETHUSDT" in engine.model_params
+
+
+def test_record_prediction_outcome_and_confidence_calibration():
+    engine = PredictiveEngine()
+
+    # Build history where bullish is correct ~80% of the time
+    for idx in range(25):
+        entry = 100.0
+        realized = 101.0 if idx < 20 else 99.0
+        engine.record_prediction_outcome("BTCUSDT", "bullish", entry, realized)
+
+    history = engine.prediction_history["BTCUSDT"]
+    assert len(history) == 25
+    assert history[-1]["predicted_direction"] == "bullish"
+
+    calibrated = engine._calibrate_confidence("BTCUSDT", 0.50, "bullish")
+    # Pull toward empirical hit-rate (0.8) from baseline 0.50 => should increase
+    assert calibrated > 0.50
+    assert calibrated <= 0.95
+
+
+def test_tune_model_for_symbol_insufficient_data():
+    engine = PredictiveEngine()
+    prices = _generate_prices(30)
+
+    result = engine.tune_model_for_symbol("SOLUSDT", prices, horizon=5, min_samples=120)
+
+    assert result["status"] == "insufficient_data"
+    assert result["required_samples"] == 120
+    assert result["available_samples"] == 30


### PR DESCRIPTION
### Motivation
- Improve price prediction quality by combining trend, momentum, and mean-reversion signals into a blended forecast. 
- Allow per-symbol parameter tuning and online calibration to make confidence estimates more robust and adaptive. 
- Replace a simplistic SMA-only prediction with richer features (EMA, returns, trend slope) and a bounded confidence model. 

### Description
- Reworked `predict_price` to compute returns, EMA, momentum, linear-trend slope, normalized signals, and a blended `expected_return`, and to return `model_version: "blended_signal_v2"` and `expected_return` in the prediction payload. 
- Introduced per-symbol configuration storage with `model_params`, default parameter set `default_params`, and a prediction history buffer `prediction_history` for empirical calibration. 
- Added `record_prediction_outcome` to record realized outcomes and `_calibrate_confidence` to pull confidence toward empirical hit rates. 
- Implemented parameter tuning and evaluation functions: `tune_model_for_symbol`, `_cross_validated_accuracy`, `_directional_accuracy`, and `_predict_with_params` to perform time-series style walk-forward tuning and select best weights. 

### Testing
- Ran the project's automated test suite with `pytest -q` against the modified module and ran static checks with `flake8`; both completed without failures. 
- Exercised `predict_price` on representative historical price series to verify output shape and keys, and validated tuning flow by invoking `tune_model_for_symbol` on synthetic data; these automated smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13fecb6dc83268c349e26acc66320)