### PR TITLE
Add recursive self-improvement loop with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ start_nexlify.bat
 - **[Environment Settings](docs/ENVIRONMENT_SETTINGS.md)** - Configuration options
 - **[Advanced Features](docs/ADVANCED_FEATURES_GUIDE.md)** - DeFi, profit management, and more
 - **[Enhancements Guide](docs/ENHANCEMENTS_GUIDE.md)** - Feature enhancements and updates
+- **[Self-Improvement Loop Guide](docs/SELF_IMPROVEMENT_LOOP_GUIDE.md)** - Recursive strategy/model/exchange automation
 
 ## 🎮 Basic Usage
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -81,6 +81,13 @@ start_nexlify.bat
 - 🔴 **Red**: Loss/Danger
 - 🔵 **Blue**: Neutral/Info
 
+## 🧠 Recursive Self-Improvement (Training)
+
+- Core module: `nexlify/training/self_improvement_loop.py`
+- Use `RecursiveSelfImprover` for candidate generation + champion promotion
+- Use `AutomatedSelfImprovementRunner` for automated evaluator-based scoring and repeated rounds
+- Full guide: [SELF_IMPROVEMENT_LOOP_GUIDE.md](SELF_IMPROVEMENT_LOOP_GUIDE.md)
+
 ## 🛠️ Common Tasks
 
 ### Change BTC Wallet

--- a/docs/SELF_IMPROVEMENT_LOOP_GUIDE.md
+++ b/docs/SELF_IMPROVEMENT_LOOP_GUIDE.md
@@ -1,0 +1,101 @@
+# Recursive Self-Improvement Guide
+
+This guide explains how Nexlify's recursive self-improvement system works, what is automated, and how to plug in your own evaluators.
+
+## What it is
+
+The self-improvement system is implemented in:
+
+- `nexlify/training/self_improvement_loop.py`
+
+It contains two layers:
+
+1. **`RecursiveSelfImprover`** (core loop)
+   - generates candidate combinations (exchange, strategy family, model type, risk profile),
+   - evaluates each candidate,
+   - tracks full history,
+   - promotes a champion (best-so-far candidate).
+
+2. **`AutomatedSelfImprovementRunner`** (automation layer)
+   - runs multiple evaluators per candidate,
+   - combines metrics into a weighted score,
+   - executes one-shot or continuous rounds automatically,
+   - logs automation sessions.
+
+## Is it automated?
+
+**Yes, when you use `AutomatedSelfImprovementRunner`.**
+
+- `RecursiveSelfImprover` by itself is orchestration logic and needs an evaluation function.
+- `AutomatedSelfImprovementRunner` makes the process operational by calling registered evaluators, scoring candidates, and recursively running improvement rounds.
+
+## Core data structures
+
+- **`StrategyCandidate`**: one generated strategy proposal.
+- **`CandidateEvaluation`**: candidate + numeric score + metric breakdown + timestamp.
+
+## Typical flow
+
+1. Configure search space (exchanges, strategy families, model types, risk profiles).
+2. Register evaluator functions.
+3. Set metric weights.
+4. Run `run_once(cycles=...)` for one automated batch.
+5. Run `run_continuous(rounds=..., cycles_per_round=...)` for long-running improvement.
+6. Consume `improver.champion_snapshot()` and `runner.automation_log`.
+
+## Minimal example
+
+```python
+from nexlify.training import RecursiveSelfImprover, AutomatedSelfImprovementRunner
+
+improver = RecursiveSelfImprover(
+    {
+        "max_candidates_per_generation": 6,
+        "exchanges": ["binance", "coinbase", "kraken"],
+        "strategy_families": ["trend_following", "mean_reversion", "breakout"],
+        "model_types": ["dqn", "double_dqn"],
+        "risk_profiles": ["conservative", "balanced"],
+        "base_params": {"learning_rate": 0.001, "gamma": 0.99},
+    }
+)
+
+runner = AutomatedSelfImprovementRunner(
+    improver=improver,
+    evaluators={
+        "return": lambda c: 1.2 if c.exchange == "coinbase" else 0.8,
+        "risk": lambda c: 0.7,
+        "latency": lambda c: 0.9,
+    },
+    metric_weights={
+        "return": 0.6,
+        "risk": 0.3,
+        "latency": 0.1,
+    },
+)
+
+champion = runner.run_continuous(rounds=3, cycles_per_round=2)
+print(champion.score)
+print(improver.champion_snapshot())
+```
+
+## Evaluator design recommendations
+
+- Keep each evaluator focused (e.g., one for return, one for drawdown/risk, one for slippage).
+- Return normalized values where possible, so weights are meaningful.
+- Make evaluators deterministic in tests and robust in production.
+- If integrating backtesting/paper trading, include timeouts and failure fallbacks.
+
+## Safety notes
+
+- This module **does not place trades by itself**.
+- It selects the best candidate according to evaluator outputs.
+- Execution should remain behind existing risk controls and paper-trading validation before deployment.
+
+## Related APIs
+
+Exports available from `nexlify.training`:
+
+- `StrategyCandidate`
+- `CandidateEvaluation`
+- `RecursiveSelfImprover`
+- `AutomatedSelfImprovementRunner`

--- a/nexlify/training/__init__.py
+++ b/nexlify/training/__init__.py
@@ -39,6 +39,13 @@ from nexlify.training.paper_trading_integration import (
     run_quick_paper_test,
 )
 
+from nexlify.training.self_improvement_loop import (
+    StrategyCandidate,
+    CandidateEvaluation,
+    RecursiveSelfImprover,
+    AutomatedSelfImprovementRunner,
+)
+
 __all__ = [
     # Training optimizers
     "GradientClipper",
@@ -64,4 +71,9 @@ __all__ = [
     "create_paper_test_from_manifest",
     "test_all_models",
     "run_quick_paper_test",
+    # Recursive self-improvement
+    "StrategyCandidate",
+    "CandidateEvaluation",
+    "RecursiveSelfImprover",
+    "AutomatedSelfImprovementRunner",
 ]

--- a/nexlify/training/self_improvement_loop.py
+++ b/nexlify/training/self_improvement_loop.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Recursive self-improvement loop for strategy/model/exchange selection.
+
+This module provides a safe orchestration layer that can:
+- generate strategy candidates from configurable templates,
+- evaluate them with a pluggable scoring callback,
+- promote the best candidate into the active policy,
+- and iterate for multiple generations.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from itertools import product
+from typing import Callable, Dict, List, Optional
+
+
+@dataclass
+class StrategyCandidate:
+    """Single strategy/model/exchange proposal in a generation."""
+
+    generation: int
+    name: str
+    exchange: str
+    strategy_family: str
+    model_type: str
+    risk_profile: str
+    params: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class CandidateEvaluation:
+    """Evaluation output for a candidate."""
+
+    candidate: StrategyCandidate
+    score: float
+    metrics: Dict[str, float] = field(default_factory=dict)
+    timestamp_utc: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+class RecursiveSelfImprover:
+    """Evolutionary coordinator for recursive strategy improvement."""
+
+    def __init__(self, config: Optional[Dict] = None):
+        cfg = config or {}
+        self.max_candidates_per_generation = int(cfg.get("max_candidates_per_generation", 12))
+        self.exchanges = list(cfg.get("exchanges", ["binance", "coinbase"]))
+        self.strategy_families = list(
+            cfg.get(
+                "strategy_families",
+                ["trend_following", "mean_reversion", "breakout", "market_making"],
+            )
+        )
+        self.model_types = list(cfg.get("model_types", ["dqn", "double_dqn", "ensemble"]))
+        self.risk_profiles = list(cfg.get("risk_profiles", ["conservative", "balanced", "aggressive"]))
+        self.base_params = dict(cfg.get("base_params", {"learning_rate": 0.001, "gamma": 0.99}))
+
+        self._history: List[CandidateEvaluation] = []
+        self._champion: Optional[CandidateEvaluation] = None
+
+    @property
+    def history(self) -> List[CandidateEvaluation]:
+        return list(self._history)
+
+    @property
+    def champion(self) -> Optional[CandidateEvaluation]:
+        return self._champion
+
+    def _candidate_name(self, generation: int, index: int, exchange: str, family: str, model: str) -> str:
+        return f"gen{generation}_c{index}_{exchange}_{family}_{model}"
+
+    def generate_candidates(self, generation: int, seed_candidate: Optional[StrategyCandidate] = None) -> List[StrategyCandidate]:
+        """Generate candidate pool for a generation."""
+        candidates: List[StrategyCandidate] = []
+
+        for idx, (exchange, family, model, risk) in enumerate(
+            product(self.exchanges, self.strategy_families, self.model_types, self.risk_profiles),
+            start=1,
+        ):
+            params = dict(self.base_params)
+
+            if seed_candidate is not None:
+                params.update(seed_candidate.params)
+                params["learning_rate"] = max(1e-5, float(params.get("learning_rate", 0.001)) * 0.98)
+                params["gamma"] = min(0.9999, float(params.get("gamma", 0.99)) + 0.0005)
+
+            candidates.append(
+                StrategyCandidate(
+                    generation=generation,
+                    name=self._candidate_name(generation, idx, exchange, family, model),
+                    exchange=exchange,
+                    strategy_family=family,
+                    model_type=model,
+                    risk_profile=risk,
+                    params=params,
+                )
+            )
+
+            if len(candidates) >= self.max_candidates_per_generation:
+                break
+
+        return candidates
+
+    def evaluate_generation(
+        self,
+        generation: int,
+        evaluate_fn: Callable[[StrategyCandidate], Dict[str, float]],
+    ) -> CandidateEvaluation:
+        """Evaluate one generation and return the winner."""
+        seed = self._champion.candidate if self._champion else None
+        candidates = self.generate_candidates(generation=generation, seed_candidate=seed)
+
+        evaluated: List[CandidateEvaluation] = []
+        for candidate in candidates:
+            result = evaluate_fn(candidate)
+            score = float(result.get("score", 0.0))
+            metrics = {k: float(v) for k, v in result.items() if k != "score"}
+            evaluated.append(CandidateEvaluation(candidate=candidate, score=score, metrics=metrics))
+
+        winner = max(evaluated, key=lambda item: item.score)
+        self._history.extend(evaluated)
+
+        if self._champion is None or winner.score > self._champion.score:
+            self._champion = winner
+
+        return winner
+
+    def run_recursive_cycles(
+        self,
+        cycles: int,
+        evaluate_fn: Callable[[StrategyCandidate], Dict[str, float]],
+    ) -> CandidateEvaluation:
+        """Run multiple generations and return the best overall strategy."""
+        if cycles <= 0:
+            raise ValueError("cycles must be > 0")
+
+        latest_winner: Optional[CandidateEvaluation] = None
+        for generation in range(1, cycles + 1):
+            latest_winner = self.evaluate_generation(generation=generation, evaluate_fn=evaluate_fn)
+
+        if self._champion is None:
+            raise RuntimeError("No champion selected during recursive cycles")
+
+        return self._champion if latest_winner is not None else self._champion
+
+    def champion_snapshot(self) -> Dict:
+        """Get serializable champion payload for logging/storage."""
+        if self._champion is None:
+            return {}
+
+        return {
+            "score": self._champion.score,
+            "metrics": dict(self._champion.metrics),
+            "candidate": asdict(self._champion.candidate),
+            "timestamp_utc": self._champion.timestamp_utc,
+        }
+
+
+class AutomatedSelfImprovementRunner:
+    """
+    Fully automated wrapper around RecursiveSelfImprover.
+
+    It evaluates every generated candidate through registered evaluators
+    (e.g., backtest, paper trading, latency, risk), computes a weighted score,
+    and continuously runs recursive improvement cycles.
+    """
+
+    def __init__(
+        self,
+        improver: RecursiveSelfImprover,
+        evaluators: Dict[str, Callable[[StrategyCandidate], float]],
+        metric_weights: Optional[Dict[str, float]] = None,
+    ):
+        if not evaluators:
+            raise ValueError("At least one evaluator is required for automation")
+
+        self.improver = improver
+        self.evaluators = dict(evaluators)
+        default_weight = 1.0 / len(self.evaluators)
+        self.metric_weights = {
+            name: float((metric_weights or {}).get(name, default_weight))
+            for name in self.evaluators
+        }
+        self.automation_log: List[Dict] = []
+
+    def evaluate_candidate(self, candidate: StrategyCandidate) -> Dict[str, float]:
+        """Run all evaluators and combine to a single score."""
+        metrics: Dict[str, float] = {}
+        weighted_score = 0.0
+
+        for metric_name, evaluator in self.evaluators.items():
+            metric_value = float(evaluator(candidate))
+            metrics[metric_name] = metric_value
+            weighted_score += metric_value * self.metric_weights.get(metric_name, 0.0)
+
+        metrics["score"] = weighted_score
+        return metrics
+
+    def run_once(self, cycles: int = 1) -> CandidateEvaluation:
+        """Run one fully automated improvement session."""
+        champion = self.improver.run_recursive_cycles(
+            cycles=cycles,
+            evaluate_fn=self.evaluate_candidate,
+        )
+        self.automation_log.append(
+            {
+                "cycles": cycles,
+                "champion": self.improver.champion_snapshot(),
+                "evaluators": list(self.evaluators.keys()),
+            }
+        )
+        return champion
+
+    def run_continuous(
+        self,
+        rounds: int,
+        cycles_per_round: int = 1,
+        sleep_seconds: float = 0.0,
+    ) -> CandidateEvaluation:
+        """Run repeated automated rounds and return current global champion."""
+        if rounds <= 0:
+            raise ValueError("rounds must be > 0")
+
+        for _ in range(rounds):
+            self.run_once(cycles=cycles_per_round)
+            if sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+
+        if self.improver.champion is None:
+            raise RuntimeError("Automation completed without selecting champion")
+        return self.improver.champion

--- a/nexlify/training/self_improvement_loop.py
+++ b/nexlify/training/self_improvement_loop.py
@@ -76,8 +76,12 @@ class RecursiveSelfImprover:
         """Generate candidate pool for a generation."""
         candidates: List[StrategyCandidate] = []
 
-        for idx, (exchange, family, model, risk) in enumerate(
-            product(self.exchanges, self.strategy_families, self.model_types, self.risk_profiles),
+        # IMPORTANT: keep exchanges as the innermost loop so that when
+        # max_candidates_per_generation truncates the cartesian product,
+        # candidate selection still spans all exchanges instead of being
+        # biased toward the first configured exchange.
+        for idx, (family, model, risk, exchange) in enumerate(
+            product(self.strategy_families, self.model_types, self.risk_profiles, self.exchanges),
             start=1,
         ):
             params = dict(self.base_params)

--- a/tests/test_recursive_self_improver.py
+++ b/tests/test_recursive_self_improver.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "nexlify" / "training" / "self_improvement_loop.py"
+spec = importlib.util.spec_from_file_location("self_improvement_loop", MODULE_PATH)
+self_improvement_loop = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = self_improvement_loop
+spec.loader.exec_module(self_improvement_loop)
+RecursiveSelfImprover = self_improvement_loop.RecursiveSelfImprover
+AutomatedSelfImprovementRunner = self_improvement_loop.AutomatedSelfImprovementRunner
+
+
+def test_generate_candidates_respects_cap():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 3,
+            "exchanges": ["binance", "kraken"],
+            "strategy_families": ["trend_following", "mean_reversion"],
+            "model_types": ["dqn"],
+            "risk_profiles": ["balanced"],
+        }
+    )
+
+    candidates = improver.generate_candidates(generation=1)
+
+    assert len(candidates) == 3
+    assert all(c.generation == 1 for c in candidates)
+
+
+def test_recursive_cycles_promote_best_champion():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 4,
+            "exchanges": ["binance", "coinbase"],
+            "strategy_families": ["trend_following", "breakout"],
+            "model_types": ["dqn"],
+            "risk_profiles": ["balanced"],
+        }
+    )
+
+    def evaluate(candidate):
+        bonus = 1.0 if candidate.exchange == "coinbase" else 0.5
+        return {
+            "score": bonus + (0.2 if candidate.strategy_family == "breakout" else 0.1),
+            "sharpe": 1.25,
+            "max_drawdown": 4.5,
+        }
+
+    champion = improver.run_recursive_cycles(cycles=2, evaluate_fn=evaluate)
+
+    assert champion.score > 0
+    assert improver.champion is not None
+    assert improver.champion.candidate.exchange == "coinbase"
+    assert len(improver.history) == 8
+
+
+def test_recursive_cycles_invalid_input():
+    improver = RecursiveSelfImprover()
+
+    def evaluate(_candidate):
+        return {"score": 1.0}
+
+    try:
+        improver.run_recursive_cycles(cycles=0, evaluate_fn=evaluate)
+        assert False, "Expected ValueError for cycles <= 0"
+    except ValueError:
+        assert True
+
+
+def test_automated_runner_scores_and_promotes():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 2,
+            "exchanges": ["binance", "coinbase"],
+            "strategy_families": ["trend_following"],
+            "model_types": ["dqn"],
+            "risk_profiles": ["balanced"],
+        }
+    )
+
+    runner = AutomatedSelfImprovementRunner(
+        improver=improver,
+        evaluators={
+            "return": lambda c: 1.0 if c.exchange == "coinbase" else 0.2,
+            "risk": lambda c: 0.8,
+        },
+        metric_weights={"return": 0.7, "risk": 0.3},
+    )
+
+    champion = runner.run_once(cycles=1)
+
+    assert champion.score > 0
+    assert improver.champion is not None
+    assert improver.champion.candidate.exchange == "coinbase"
+    assert len(runner.automation_log) == 1
+
+
+def test_automated_runner_rejects_empty_evaluators():
+    improver = RecursiveSelfImprover()
+
+    try:
+        AutomatedSelfImprovementRunner(improver=improver, evaluators={})
+        assert False, "Expected ValueError for empty evaluator set"
+    except ValueError:
+        assert True

--- a/tests/test_recursive_self_improver.py
+++ b/tests/test_recursive_self_improver.py
@@ -108,3 +108,122 @@ def test_automated_runner_rejects_empty_evaluators():
         assert False, "Expected ValueError for empty evaluator set"
     except ValueError:
         assert True
+
+
+
+def test_champion_snapshot_empty_before_training():
+    improver = RecursiveSelfImprover()
+    assert improver.champion_snapshot() == {}
+
+
+def test_seeded_generation_mutates_params_with_bounds():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 1,
+            "base_params": {"learning_rate": 0.001, "gamma": 0.99},
+        }
+    )
+
+    seed = self_improvement_loop.StrategyCandidate(
+        generation=1,
+        name="seed",
+        exchange="binance",
+        strategy_family="trend_following",
+        model_type="dqn",
+        risk_profile="balanced",
+        params={"learning_rate": 0.000001, "gamma": 0.9999},
+    )
+
+    candidates = improver.generate_candidates(generation=2, seed_candidate=seed)
+
+    assert len(candidates) == 1
+    params = candidates[0].params
+    assert params["learning_rate"] == 1e-5
+    assert params["gamma"] == 0.9999
+
+
+def test_evaluate_generation_defaults_missing_score_and_preserves_champion():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 2,
+            "exchanges": ["binance", "coinbase"],
+            "strategy_families": ["trend_following"],
+            "model_types": ["dqn"],
+            "risk_profiles": ["balanced"],
+        }
+    )
+
+    winner_1 = improver.evaluate_generation(
+        generation=1,
+        evaluate_fn=lambda _c: {"score": 5, "sharpe": 1},
+    )
+    assert winner_1.score == 5.0
+
+    winner_2 = improver.evaluate_generation(
+        generation=2,
+        evaluate_fn=lambda _c: {"sharpe": 0.5},
+    )
+
+    assert winner_2.score == 0.0
+    assert improver.champion is not None
+    assert improver.champion.score == 5.0
+
+
+def test_runner_uses_default_weights_and_continuous_rounds():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 1,
+            "exchanges": ["binance"],
+            "strategy_families": ["trend_following"],
+            "model_types": ["dqn"],
+            "risk_profiles": ["balanced"],
+        }
+    )
+
+    runner = AutomatedSelfImprovementRunner(
+        improver=improver,
+        evaluators={"m1": lambda _c: 2.0, "m2": lambda _c: 4.0},
+    )
+
+    sample = self_improvement_loop.StrategyCandidate(
+        generation=1,
+        name="x",
+        exchange="binance",
+        strategy_family="trend_following",
+        model_type="dqn",
+        risk_profile="balanced",
+    )
+    metrics = runner.evaluate_candidate(sample)
+    assert metrics["score"] == 3.0
+
+    champion = runner.run_continuous(rounds=2, cycles_per_round=1)
+    assert champion.score > 0
+    assert len(runner.automation_log) == 2
+
+
+def test_runner_continuous_runtime_error_when_no_champion_and_invalid_rounds():
+    class BrokenImprover:
+        champion = None
+
+        def run_recursive_cycles(self, cycles, evaluate_fn):
+            return None
+
+        def champion_snapshot(self):
+            return {}
+
+    runner = AutomatedSelfImprovementRunner(
+        improver=BrokenImprover(),
+        evaluators={"m1": lambda _c: 1.0},
+    )
+
+    try:
+        runner.run_continuous(rounds=0)
+        assert False, "Expected ValueError for rounds <= 0"
+    except ValueError:
+        assert True
+
+    try:
+        runner.run_continuous(rounds=1)
+        assert False, "Expected RuntimeError when no champion is produced"
+    except RuntimeError:
+        assert True

--- a/tests/test_recursive_self_improver.py
+++ b/tests/test_recursive_self_improver.py
@@ -32,6 +32,25 @@ def test_generate_candidates_respects_cap():
     assert all(c.generation == 1 for c in candidates)
 
 
+def test_generate_candidates_not_biased_to_first_exchange_when_capped():
+    improver = RecursiveSelfImprover(
+        {
+            "max_candidates_per_generation": 12,
+            "exchanges": ["binance", "coinbase"],
+            "strategy_families": ["trend_following", "mean_reversion", "breakout", "market_making"],
+            "model_types": ["dqn", "double_dqn", "ensemble"],
+            "risk_profiles": ["conservative", "balanced", "aggressive"],
+        }
+    )
+
+    candidates = improver.generate_candidates(generation=1)
+    exchanges = {c.exchange for c in candidates}
+
+    assert len(candidates) == 12
+    assert "binance" in exchanges
+    assert "coinbase" in exchanges
+
+
 def test_recursive_cycles_promote_best_champion():
     improver = RecursiveSelfImprover(
         {


### PR DESCRIPTION
### Motivation

- Provide an orchestration layer to automatically generate, evaluate, and promote strategy/model/exchange candidates for continuous improvement. 
- Surface the new capability in user documentation and make the API available from the `nexlify.training` package. 

### Description

- Add `nexlify/training/self_improvement_loop.py` implementing `StrategyCandidate`, `CandidateEvaluation`, `RecursiveSelfImprover`, and `AutomatedSelfImprovementRunner` with generation, evaluation, scoring, and continuous-run helpers. 
- Export the new classes from `nexlify/training/__init__.py` so they are available via `from nexlify.training import ...`. 
- Add user-facing documentation links in `README.md` and `docs/QUICK_REFERENCE.md` and a full guide file `docs/SELF_IMPROVEMENT_LOOP_GUIDE.md` describing usage and examples. 
- Add unit tests in `tests/test_recursive_self_improver.py` covering candidate generation caps, champion promotion across cycles, input validation, evaluator scoring, and runner behavior. 

### Testing

- Ran the new unit test file `tests/test_recursive_self_improver.py` under the test suite using `pytest`, and all tests passed. 
- The tests exercise `RecursiveSelfImprover.generate_candidates`, `run_recursive_cycles`, and `AutomatedSelfImprovementRunner` behavior and validation scenarios and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2857a26d08326a52f622d491585b1)