### PR TITLE
Fail fast in preflight checker when Python runtime is unsupported

### DIFF
--- a/nexlify_preflight_checker.py
+++ b/nexlify_preflight_checker.py
@@ -17,6 +17,7 @@ Provides:
 """
 
 import logging
+import importlib
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
@@ -27,16 +28,33 @@ import time
 # Add project root to path
 sys.path.append(str(Path(__file__).parent.parent))
 
-try:
-    import ccxt
-    import requests
-    import torch
-    import pandas as pd
-    import numpy as np
-except ImportError as e:
-    print(f"❌ Missing dependency: {e}")
-    print("Please run: pip install -r requirements.txt")
-    sys.exit(1)
+MIN_PYTHON = (3, 12)
+
+
+def _validate_runtime_requirements() -> None:
+    """Fail fast with actionable guidance when runtime prerequisites are missing."""
+    if sys.version_info < MIN_PYTHON:
+        required = ".".join(map(str, MIN_PYTHON))
+        current = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        print(f"❌ Unsupported Python version: {current}")
+        print(f"Nexlify requires Python {required}+ for testing and model training.")
+        print("Please create a Python 3.12+ environment, then run: pip install -r requirements.txt")
+        sys.exit(1)
+
+    missing = []
+    for package_name in ("ccxt", "requests", "torch", "pandas", "numpy"):
+        try:
+            globals()[package_name] = importlib.import_module(package_name)
+        except ImportError:
+            missing.append(package_name)
+
+    if missing:
+        print(f"❌ Missing dependency: {', '.join(missing)}")
+        print("Please run: pip install -r requirements.txt")
+        sys.exit(1)
+
+
+_validate_runtime_requirements()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Motivation

- Ensure the pre-flight checker enforces the repository's Python requirement (3.12+) and gives actionable guidance instead of surfacing misleading missing-package errors.

### Description

- Added `MIN_PYTHON` and a `_validate_runtime_requirements()` helper that exits early when `sys.version_info` is below `3.12` and instructs the user to create a Python 3.12+ environment.
- Replaced the single `try/except ImportError` block with an `importlib`-based startup check that attempts to import core packages (`ccxt`, `requests`, `torch`, `pandas`, `numpy`) and reports all missing packages in one message before exiting.
- Kept the rest of the preflight checks unchanged and preserved an actionable troubleshooting message pointing to `pip install -r requirements.txt`.

### Testing

- Ran `python nexlify_preflight_checker.py --automated` and confirmed it now fails with a clear "Unsupported Python version" message under Python 3.10 (expected behavior). 
- Ran `python -m pytest tests/test_verify_docs_vs_code.py` which passed (`3 passed`).
- Ran `python -m pytest tests/test_training_optimizers.py tests/test_rl_agent.py tests/test_walk_forward.py` which errored during collection due to missing `numpy` in the current environment (environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b571cd35348326a1f8c763db610ee2)